### PR TITLE
nodes: Collect logs from "/run/vc/"

### DIFF
--- a/collection-scripts/gather_nodes
+++ b/collection-scripts/gather_nodes
@@ -94,6 +94,14 @@ gather_single_pod() {
     if oc exec "$pod" -n node-gather -- [ -f /host/etc/pcidp/config.json ] 2>/dev/null; then
         oc cp "$pod:/host/etc/pcidp/config.json" "$NODE_PATH/pcidp_config.json" -n node-gather 2>/dev/null
     fi
+
+    if oc exec "$pod" -n node-gather -- [ -d "/host/run/vc" ] 2>/dev/null; then
+        echo "Collecting sandboxed-containers specific logs"
+
+        VC_PATH="$NODE_PATH/run/vc/"
+        mkdir -p "${VC_PATH}"
+        oc cp "$pod:/host/run/vc/" "${VC_PATH}" -n node-gather 2>/dev/null
+    fi
 }
 
 for line in $(oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name --no-headers --field-selector=status.phase=Running -n node-gather)

--- a/node-gather/node-gather-ds.yaml
+++ b/node-gather/node-gather-ds.yaml
@@ -50,6 +50,8 @@ spec:
             mountPath: /host/opt
           - name: var
             mountPath: /host/var            
+          - name: run
+            mountPath: /host/run
         securityContext:
           privileged: true
       volumes:
@@ -77,4 +79,7 @@ spec:
         hostPath:
           path: /var
           type: Directory
-
+      - name: run
+        hostPath:
+          path: /run
+          type: Directory


### PR DESCRIPTION
kata-containers stores a few things on `/run/vc`, such as:
* QEMU logs, under `/run/vc/vms/${sandbox-id}/`
* Sandbox JSON files, unser `/run/vc/sbs/${sandbox-id}/`

With this in mind, let's fully collect the content of `/run/vc`.

Fixes: #3

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>