### PR TITLE
sandboxed-containers: collect sandboxed-containers-operator (and related) logs & descriptions

### DIFF
--- a/collection-scripts/gather
+++ b/collection-scripts/gather
@@ -36,4 +36,7 @@ done
 # Workaround for: https://github.com/openshift/must-gather/issues/122
 /usr/bin/gather_images
 
+# Collect sandboxed-containers details
+/usr/bin/gather_sandboxed_containers_logs
+
 exit 0

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -70,4 +70,5 @@ mkdir -p ${LIFECYCLE_MANAGER_NS}
 
 for pod in $(oc get pods -n openshift-operator-lifecycle-manager -o'custom-columns=name:metadata.name' --no-headers); do
     oc logs "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
+    oc describe pod "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_description"
 done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -9,3 +9,19 @@ OSC_PATH=${BASE_COLLECTION_PATH}/sandboxed-containers
 mkdir -p ${OSC_PATH}
 
 oc describe kataconfig > "${OSC_PATH}/kataconfig_description"
+
+# operators
+operators=()
+#  logs from everything in the following operators namespaces
+#  - openshift-sandboxed-containers-operator
+operators+=(openshift-sandboxed-containers-operator)
+
+NAMESPACE_PATH=${OSC_PATH}/namespaces
+for operator in "${operators[@]}"; do
+    OPERATOR_NS=${NAMESPACE_PATH}/${operator}
+    mkdir -p ${OPERATOR_NS}
+
+    for pod in $(oc get pods -n "${operator}" -o'custom-columns=name:metadata.name' --no-headers); do
+        oc logs "${pod}" -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
+    done
+done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -27,3 +27,16 @@ for operator in "${operators[@]}"; do
         oc logs "${pod}" -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
     done
 done
+
+# mcps
+mcps=()
+#  description of the following mcps
+#  - master
+mcps+=(master)
+
+MCP_PATH=${OSC_PATH}/mcps
+mkdir -p ${MCP_PATH}
+
+for mcp in "${mcps[@]}"; do
+    oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
+done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -46,3 +46,11 @@ for mcp in "${mcps[@]}"; do
         oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
     fi	    
 done
+
+# installplans
+INSTALLPLAN_NS=${NAMESPACE_PATH}/openshift-sandboxed-containers-operator
+mkdir -p ${INSTALLPLAN_NS}
+
+for installplan in $(oc get installplans -n openshift-sandboxed-containers-operator -o'custom-columns=name:metadata.name' --no-headers); do
+    oc describe installplan ${installplan} -n openshift-sandboxed-containers-operator > "${INSTALLPLAN_NS}/${installplan}_description"
+done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -32,7 +32,9 @@ done
 mcps=()
 #  description of the following mcps
 #  - master
+#  - worker
 mcps+=(master)
+mcps+=(worker)
 
 MCP_PATH=${OSC_PATH}/mcps
 mkdir -p ${MCP_PATH}

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -24,7 +24,7 @@ for operator in "${operators[@]}"; do
     mkdir -p ${OPERATOR_NS}
 
     for pod in $(oc get pods -n "${operator}" -o'custom-columns=name:metadata.name' --no-headers); do
-        oc logs "${pod}" -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
+        oc logs "${pod}" --all-containers -n "${operator}" > "${OPERATOR_NS}/${pod}_logs"
     done
 done
 
@@ -60,7 +60,7 @@ MARKETPLACE_NS=${NAMESPACE_PATH}/openshift-marketplace
 mkdir -p ${MARKETPLACE_NS}
 
 for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadata.name' --no-headers); do
-    oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
+    oc logs "${pod}" --all-containers -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
     oc describe pod "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_description"
 done
 
@@ -69,6 +69,6 @@ LIFECYCLE_MANAGER_NS=${LIFECYCLE_MANAGER_NS}/openshift-operator-lifecycle-manage
 mkdir -p ${LIFECYCLE_MANAGER_NS}
 
 for pod in $(oc get pods -n openshift-operator-lifecycle-manager -o'custom-columns=name:metadata.name' --no-headers); do
-    oc logs "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
+    oc logs "${pod}" --all-containers -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
     oc describe pod "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_description"
 done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -33,12 +33,16 @@ mcps=()
 #  description of the following mcps
 #  - master
 #  - worker
+#  - kata-oc
 mcps+=(master)
 mcps+=(worker)
+mcps+=(kata-oc)
 
 MCP_PATH=${OSC_PATH}/mcps
 mkdir -p ${MCP_PATH}
 
 for mcp in "${mcps[@]}"; do
-    oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
+    if $(oc get mcp $mcp &>/dev/null); then
+        oc describe mcp $mcp > "${MCP_PATH}/${mcp}_description"
+    fi	    
 done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+IFS=$'\n'
+
+BASE_COLLECTION_PATH="/must-gather"
+
+# kataconfig
+OSC_PATH=${BASE_COLLECTION_PATH}/sandboxed-containers
+mkdir -p ${OSC_PATH}
+
+oc describe kataconfig > "${OSC_PATH}/kataconfig_description"

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -63,3 +63,11 @@ for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadat
     oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
     oc describe pod "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_description"
 done
+
+# lifecycle-manager
+LIFECYCLE_MANAGER_NS=${LIFECYCLE_MANAGER_NS}/openshift-operator-lifecycle-manager
+mkdir -p ${LIFECYCLE_MANAGER_NS}
+
+for pod in $(oc get pods -n openshift-operator-lifecycle-manager -o'custom-columns=name:metadata.name' --no-headers); do
+    oc logs "${pod}" -n openshift-operator-lifecycle-manager > "${LIFECYCLE_MANAGER_NS}/${pod}_logs"
+done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -54,3 +54,11 @@ mkdir -p ${INSTALLPLAN_NS}
 for installplan in $(oc get installplans -n openshift-sandboxed-containers-operator -o'custom-columns=name:metadata.name' --no-headers); do
     oc describe installplan ${installplan} -n openshift-sandboxed-containers-operator > "${INSTALLPLAN_NS}/${installplan}_description"
 done
+
+# marketplace
+MARKETPLACE_NS=${NAMESPACE_PATH}/openshift-marketplace
+mkdir -p ${MARKETPLACE_NS}
+
+for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadata.name' --no-headers); do
+    oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
+done

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -14,7 +14,9 @@ oc describe kataconfig > "${OSC_PATH}/kataconfig_description"
 operators=()
 #  logs from everything in the following operators namespaces
 #  - openshift-sandboxed-containers-operator
+#  - openshift-machine-config-operator
 operators+=(openshift-sandboxed-containers-operator)
+operators+=(openshift-machine-config-operator)
 
 NAMESPACE_PATH=${OSC_PATH}/namespaces
 for operator in "${operators[@]}"; do

--- a/collection-scripts/gather_sandboxed_containers_logs
+++ b/collection-scripts/gather_sandboxed_containers_logs
@@ -61,4 +61,5 @@ mkdir -p ${MARKETPLACE_NS}
 
 for pod in $(oc get pods -n openshift-marketplace -o'custom-columns=name:metadata.name' --no-headers); do
     oc logs "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_logs"
+    oc describe pod "${pod}" -n openshift-marketplace > "${MARKETPLACE_NS}/${pod}_description"
 done


### PR DESCRIPTION
Collect a bunch of logs & descriptions which can help to debug the sandboxed-containers-operator.

The content we're collect is:
* output of `oc describe kataconfig`
* output of `oc logs $pod -n openshift-sandboxed-containers-operator`, for all pods in the openshift-sandboxed-containers-operator namespace
* outpuf of `oc logs $pod -n openshift-machine-config-operator`, for all pods in the openshift-machine-config-operator namespace
* outpuf of `oc describe mcp master`
* output of `oc describe mcp worker`
* output of `oc describe kata-oc`, when the kata-oc pool is present
* output of `oc describe installplan -n openshift-sandboxed-containers-operator`, for all installplans in the openshift-sandboxed-containers-operator namespace
* output of `oc logs $pod -n openshift-marketplace` and `oc describe pod $pod -n openshift-marketplace`, for all pods in the openshift-marketplace namespace
* output of `oc logs $pod -n openshift-operator-lifecycle-manager` and `oc describe pod $pod -n openshift-operator-lifecycle-manager` openshift-operator-lifecycle-manager namespace

Fixes: #2 